### PR TITLE
Corrected permissions for lambda functions

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -223,9 +223,8 @@ Resources:
                   - translate:TranslateText
                   - polly:SynthesizeSpeech
                 Resource:
-                  - !Sub 'arn:aws:s3:::${AudioBucket}/*'
+                  - !Sub 'arn:aws:s3:::${AudioBucket}/audio_inputs/*'
                   - !Sub 'arn:aws:s3:::${AudioBucket}'
-                  - '*'
       Tags:
         - Key: Name
           Value: !Sub "${LambdaExecutionRoleName}-${Environment}"


### PR DESCRIPTION
Corrected permissions for lambda functions to be locked down to their s3 bucket for listing and only allowed to access the prefix audio_inputs/*.

# Pull Request ✨

## Description 📝
<!-- Please include a summary of the changes and the related issue. -->

## Type of Change 🔄
<!-- Please select one or more options that apply. -->
-   [ ] Bug fix 🐛
-   [ ] New feature 🌟
-   [x] Enhancement ⚡
-   [ ] Documentation update 📚
-   [ ] Other (please describe): 

## Checklist ✅
<!-- Please check the following items. -->
-   [ ] I have read the contributing guidelines. 📖
-   [ ] I have performed a self-review of my code. 🔍
-   [ ] I have commented my code where necessary. 💬
-   [ ] My changes generate no new warnings. 🚫
-   [ ] I have added tests that prove my fix is effective or that my feature works. 🧪
-   [ ] I have updated the documentation accordingly. 📄

## Related Issues 🔗
<!-- Please link any related issues here. For example: Fixes #123 -->

## Additional Notes 🗒️
<!-- Any additional information that would be helpful for the reviewer. -->

