### PR TITLE
Removing !GetAtt as we can hardcode the policies while the resources …

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -379,14 +379,15 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/vendedlogs/states/${AudioProcessingStateMachineName}-${Environment}'
                   - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/vendedlogs/states/${AudioProcessingStateMachineName}-${Environment}/*'
-                  - !GetAtt TranscribeFunction.Arn
-                  - !GetAtt TranscribeStatusFunction.Arn
-                  - !GetAtt TranslateFunction.Arn
-                  - !GetAtt TranslateStatusFunction.Arn
-                  - !GetAtt SynthesizeFunction.Arn
-                  - !GetAtt SynthesizeStatusFunction.Arn
-                  - !GetAtt AudioProcessingStateMachine.Arn
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranscribeFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranscribeStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranslateFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranslateStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${SynthesizeFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${SynthesizeStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AudioProcessingStateMachineName}-${Environment}'
       Tags:
         - Key: Name
           Value: !Sub "${StepFunctionsRoleName}-${Environment}"
@@ -421,16 +422,16 @@ Resources:
                   - logs:PutLogEvents
                   - states:StartExecution
                 Resource:
-                  - !GetAtt AudioBucket.Arn
                   - !Sub 'arn:aws:s3:::${AudioBucket}/audio_inputs/*'
-                  - !GetAtt TriggerFunction.Arn
-                  - !GetAtt TranscribeFunction.Arn
-                  - !GetAtt TranscribeStatusFunction.Arn
-                  - !GetAtt TranslateFunction.Arn
-                  - !GetAtt TranslateStatusFunction.Arn
-                  - !GetAtt SynthesizeFunction.Arn
-                  - !GetAtt SynthesizeStatusFunction.Arn
-                  - !GetAtt AudioProcessingStateMachine.Arn
+                  - !Sub 'arn:aws:s3:::${AudioBucket}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TriggerFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranscribeFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranscribeStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranslateFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${TranslateStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${SynthesizeFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${SynthesizeStatusFunctionName}-${Environment}'
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AudioProcessingStateMachineName}-${Environment}'
         #- PolicyName: TranscribeExecutionPolicy
         #  PolicyDocument:
         #    Version: '2012-10-17'


### PR DESCRIPTION
…don't exist, we can't use !GetAtt which changes the order of operations. It created circular dependency.

# Pull Request ✨

## Description 📝
<!-- Please include a summary of the changes and the related issue. -->

## Type of Change 🔄
<!-- Please select one or more options that apply. -->
-   [ ] Bug fix 🐛
-   [ ] New feature 🌟
-   [x] Enhancement ⚡
-   [ ] Documentation update 📚
-   [ ] Other (please describe): 

## Checklist ✅
<!-- Please check the following items. -->
-   [ ] I have read the contributing guidelines. 📖
-   [ ] I have performed a self-review of my code. 🔍
-   [ ] I have commented my code where necessary. 💬
-   [ ] My changes generate no new warnings. 🚫
-   [ ] I have added tests that prove my fix is effective or that my feature works. 🧪
-   [ ] I have updated the documentation accordingly. 📄

## Related Issues 🔗
<!-- Please link any related issues here. For example: Fixes #123 -->

## Additional Notes 🗒️
<!-- Any additional information that would be helpful for the reviewer. -->

